### PR TITLE
No need for Substrate/GraalVMHome when running gluonfx:run

### DIFF
--- a/src/main/java/com/gluonhq/RunMojo.java
+++ b/src/main/java/com/gluonhq/RunMojo.java
@@ -66,12 +66,6 @@ public class RunMojo extends NativeBaseMojo {
 
     @Override
     public void execute() throws MojoExecutionException {
-        try {
-            createSubstrateDispatcher();
-        } catch (Exception e) {
-            e.printStackTrace();
-            throw new MojoExecutionException("Error creating Substrate Dispatcher", e);
-        }
 
         final InvocationRequest invocationRequest = new DefaultInvocationRequest();
         invocationRequest.setProfiles(project.getActiveProfiles().stream()


### PR DESCRIPTION
Fixes #342 