### PR TITLE
Add configurable appIdentifier

### DIFF
--- a/src/main/java/com/gluonhq/NativeBaseMojo.java
+++ b/src/main/java/com/gluonhq/NativeBaseMojo.java
@@ -137,6 +137,9 @@ public abstract class NativeBaseMojo extends AbstractMojo {
     @Parameter(property = "gluonfx.remoteDir")
     String remoteDir;
 
+    @Parameter(property = "gluonfx.appIdentifier")
+    String appIdentifier;
+
     @Parameter(property = "gluonfx.releaseConfiguration")
     ReleaseConfiguration releaseConfiguration;
 
@@ -194,7 +197,8 @@ public abstract class NativeBaseMojo extends AbstractMojo {
         clientConfig.setCompilerArgs(nativeImageArgs);
         clientConfig.setRuntimeArgs(runtimeArgs);
         clientConfig.setReflectionList(reflectionList);
-        clientConfig.setAppId(project.getGroupId() + "." + project.getArtifactId());
+        clientConfig.setAppId(appIdentifier != null ? appIdentifier :
+                project.getGroupId() + "." + project.getArtifactId());
         clientConfig.setAppName(project.getName());
         clientConfig.setVerbose("true".equals(verbose));
         clientConfig.setUsePrismSW("true".equals(enableSWRendering));


### PR DESCRIPTION
Fixes #99 at least for the package name/application identifier. 

Other platform variables can be already set with ReleaseConfiguration.