### PR TITLE
Create GitHub release during release workflow

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,0 @@
-exclude-labels:
-  - 'housekeeping'
-template: |
-  ## What’s Changed
-  $CHANGES

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,10 @@
+changelog:
+  exclude:
+    labels:
+      - housekeeping
+    authors:
+      - gluon-bot
+  categories:
+    - title: What’s Changed
+      labels:
+        - "*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,10 +38,3 @@ jobs:
         env:
           MAVEN_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           MAVEN_CENTRAL_TOKEN: ${{ secrets.SONATYPE_PASSWORD }}
-
-      - name: Draft release
-        if: github.ref == 'refs/heads/master'
-        # Drafts your next Release notes as Pull Requests are merged into "master"
-        uses: release-drafter/release-drafter@v5
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,11 @@ jobs:
           MAVEN_CENTRAL_TOKEN: ${{ secrets.SONATYPE_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Commit next development version
         if: steps.deploy.outputs.exit_code == 0
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,7 @@ jobs:
         uses: softprops/action-gh-release@v0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          generate_release_notes: true
 
       - name: Commit next development version
         if: steps.deploy.outputs.exit_code == 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Create GitHub release
         uses: softprops/action-gh-release@v0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT }}
           generate_release_notes: true
 
       - name: Commit next development version


### PR DESCRIPTION
As discussed [here](https://github.com/gluonhq/gluonfx-maven-plugin/issues/314#issuecomment-1005216616), the current release workflow doesn't create an actual GitHub release (newest tag/release is 1.0.10, whereas the current GitHub release points to [1.0.1](https://github.com/gluonhq/gluonfx-maven-plugin/releases/tag/1.0.1)). This might be confusing to some users, resulting in the use of old plugin versions.

This PR uses [`softprops/action-gh-release`](https://github.com/softprops/action-gh-release) to create a GitHub release during the release workflow. Note that the "official" [`actions/create-relase`](https://github.com/actions/create-release) is unmaintained, and `softprops/action-gh-release` is one of four recommended alternatives.

Since the [build workflow](https://github.com/beatngu13/gluonfx-maven-plugin/blob/master/.github/workflows/build.yml#L47) already uses a secret `GITHUB_TOKEN`, I assume it is available so that the action can use it to create a release via the GitHub API.