### PR TITLE
Remove unnecessary categories

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -4,7 +4,3 @@ changelog:
       - housekeeping
     authors:
       - gluon-bot
-  categories:
-    - title: What’s Changed
-      labels:
-        - "*"


### PR DESCRIPTION
The "What's changed" category is not necessary. The generated release notes already contain `<h2>What's changed</h2>`, the current configuration just adds an additional, nested `<h3>What's changed</h3>`:

https://github.com/gluonhq/gluonfx-maven-plugin/releases/tag/1.0.13

In contrast, here is the `release.yml` of a personal project _without_ categories:

https://github.com/beatngu13/pdf-zoom-wizard/blob/develop/.github/release.yml

The generated release notes:

https://github.com/beatngu13/pdf-zoom-wizard/releases/tag/v0.11.0