### PR TITLE
Fix MavenArtifactResolver issues with maven 3.9+

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,12 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Setup Java 11 and Apache Maven
-        uses: actions/setup-java@v1
+      - name: Setup Java 21 and Apache Maven
+        uses: actions/setup-java@v4
         with:
-          java-version: 11
+          distribution: 'temurin'
+          java-version: 21
           server-id: ossrh
           server-username: MAVEN_USERNAME
           server-password: MAVEN_CENTRAL_TOKEN

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,15 +9,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 5
           persist-credentials: false
 
-      - name: Setup Java 11 and Apache Maven
-        uses: actions/setup-java@v1
+      - name: Setup Java 21 and Apache Maven
+        uses: actions/setup-java@v4
         with:
-          java-version: 11
+          distribution: 'temurin'
+          java-version: 21
           server-id: ossrh
           server-username: MAVEN_USERNAME
           server-password: MAVEN_CENTRAL_TOKEN
@@ -82,7 +83,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install xmlstarlet
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 5
           persist-credentials: false

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <!--
- ~ Copyright (c) 2019, 2023, Gluon
+ ~ Copyright (c) 2019, 2024, Gluon
  ~ All rights reserved.
  ~
  ~ Redistribution and use in source and binary forms, with or without
@@ -42,12 +42,11 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.resource>21</maven.compiler.resource>
     <source.plugin.version>3.3.0</source.plugin.version>
     <javadoc.plugin.version>3.5.0</javadoc.plugin.version>
     <gpg.plugin.version>3.1.0</gpg.plugin.version>
-    <maven.resolver.version>1.7.3</maven.resolver.version>
+    <maven.plugin.version>3.9.9</maven.plugin.version>
     <substrate.version>0.0.65-SNAPSHOT</substrate.version>
   </properties>
 
@@ -60,57 +59,30 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
-      <version>3.8.8</version>
+      <version>${maven.plugin.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-core</artifactId>
+      <version>${maven.plugin.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
-      <version>3.9.0</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-java</artifactId>
-      <version>0.9.11</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-exec</artifactId>
-      <version>1.3</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-core</artifactId>
-      <version>3.8.8</version>
+      <version>3.15.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-invoker</artifactId>
-      <version>3.2.0</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-aether-provider</artifactId>
-      <version>3.3.9</version>
-      <scope>provided</scope>
+      <version>3.3.0</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.maven.resolver</groupId>
-      <artifactId>maven-resolver-transport-http</artifactId>
-      <version>${maven.resolver.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven.resolver</groupId>
-      <artifactId>maven-resolver-transport-file</artifactId>
-      <version>${maven.resolver.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven.resolver</groupId>
-      <artifactId>maven-resolver-connector-basic</artifactId>
-      <version>${maven.resolver.version}</version>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-exec</artifactId>
+      <version>1.4.0</version>
     </dependency>
   </dependencies>
 
@@ -134,12 +106,16 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.11.0</version>
+        <version>3.13.0</version>
+        <configuration>
+          <source>21</source>
+          <target>21</target>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
-        <version>3.9.0</version>
+        <version>3.15.0</version>
       </plugin>
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
@@ -155,7 +131,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.4.1</version>
+        <version>3.5.0</version>
         <executions>
           <execution>
             <id>enforce-no-snapshots</id>

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-util</artifactId>
+      <version>2.0.1</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-invoker</artifactId>
       <version>3.3.0</version>

--- a/src/main/java/com/gluonhq/NativeBaseMojo.java
+++ b/src/main/java/com/gluonhq/NativeBaseMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Gluon
+ * Copyright (c) 2019, 2024, Gluon
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -36,14 +36,12 @@ import com.gluonhq.substrate.ProjectConfiguration;
 import com.gluonhq.substrate.SubstrateDispatcher;
 import com.gluonhq.substrate.model.Triplet;
 import com.gluonhq.substrate.target.WebTargetConfiguration;
-import com.gluonhq.substrate.util.Version;
 import com.gluonhq.utils.MavenArtifactResolver;
 import org.apache.commons.exec.ProcessDestroyer;
 import org.apache.commons.exec.ShutdownHookProcessDestroyer;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Dependency;
-import org.apache.maven.model.Repository;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.BuildPluginManager;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -76,8 +74,6 @@ import static com.gluonhq.attach.AttachArtifactResolver.UTIL_ARTIFACT;
 public abstract class NativeBaseMojo extends AbstractMojo {
 
     private static final List<String> ALLOWED_DEPENDENCY_TYPES = Collections.singletonList("jar");
-
-    private static final Version MAX_SUPPORTED_MAVEN_VERSION = new Version(3, 9, 9);
 
     Path outputDir;
 
@@ -177,12 +173,6 @@ public abstract class NativeBaseMojo extends AbstractMojo {
     private ProcessDestroyer processDestroyer;
 
     public SubstrateDispatcher createSubstrateDispatcher() throws IOException, MojoExecutionException {
-        String mavenVersion = runtimeInformation.getMavenVersion();
-        Version version = new Version(mavenVersion);
-        if (version.compareTo(MAX_SUPPORTED_MAVEN_VERSION) > 0) {
-            throw new MojoExecutionException("Maven version " + mavenVersion + " is not currently supported by the GluonFX Maven Plugin.\n" +
-                    "Please downgrade your Maven version to " + MAX_SUPPORTED_MAVEN_VERSION + " and then try again.\n");
-        }
         if (getGraalvmHome().isEmpty()) {
             throw new MojoExecutionException("GraalVM installation directory not found." +
                     " Either set GRAALVM_HOME as an environment variable or" +

--- a/src/main/java/com/gluonhq/utils/MavenArtifactResolver.java
+++ b/src/main/java/com/gluonhq/utils/MavenArtifactResolver.java
@@ -93,6 +93,7 @@ public class MavenArtifactResolver {
      *
      * @param repositorySystem The entry point to Maven Artifact Resolver
      * @param systemSession The current repository/network configuration of Maven
+     * @param repositories The current list of remote repositories
      */
     public static void initRepositories(RepositorySystem repositorySystem, RepositorySystemSession systemSession, List<RemoteRepository> repositories) {
         if (instance != null) {

--- a/src/main/java/com/gluonhq/utils/MavenArtifactResolver.java
+++ b/src/main/java/com/gluonhq/utils/MavenArtifactResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Gluon
+ * Copyright (c) 2019, 2024, Gluon
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -31,45 +31,28 @@
 package com.gluonhq.utils;
 
 import org.apache.maven.artifact.handler.DefaultArtifactHandler;
-import org.apache.maven.model.Repository;
-import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
-import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.collection.CollectRequest;
-import org.eclipse.aether.connector.basic.BasicRepositoryConnectorFactory;
 import org.eclipse.aether.graph.Dependency;
 import org.eclipse.aether.graph.DependencyFilter;
-import org.eclipse.aether.impl.DefaultServiceLocator;
-import org.eclipse.aether.repository.LocalRepository;
 import org.eclipse.aether.repository.RemoteRepository;
-import org.eclipse.aether.repository.RepositoryPolicy;
 import org.eclipse.aether.resolution.ArtifactRequest;
 import org.eclipse.aether.resolution.ArtifactResolutionException;
 import org.eclipse.aether.resolution.ArtifactResult;
 import org.eclipse.aether.resolution.DependencyRequest;
 import org.eclipse.aether.resolution.DependencyResolutionException;
-import org.eclipse.aether.spi.connector.RepositoryConnectorFactory;
-import org.eclipse.aether.spi.connector.transport.TransporterFactory;
-import org.eclipse.aether.transport.file.FileTransporterFactory;
-import org.eclipse.aether.transport.http.HttpTransporterFactory;
 import org.eclipse.aether.util.artifact.JavaScopes;
 import org.eclipse.aether.util.filter.DependencyFilterUtils;
 
 import java.util.Arrays;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.Locale;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
-
-import static org.eclipse.aether.repository.RepositoryPolicy.CHECKSUM_POLICY_WARN;
-import static org.eclipse.aether.repository.RepositoryPolicy.UPDATE_POLICY_DAILY;
-import static org.eclipse.aether.repository.RepositoryPolicy.UPDATE_POLICY_NEVER;
 
 public class MavenArtifactResolver {
 
@@ -87,7 +70,7 @@ public class MavenArtifactResolver {
      *
      * If the instance hasn't been created yet, it will throw an
      * {@code IllegalStateException}. To prevent this,
-     * {@link #initRepositories(List)} has to be called first.
+     * {@link #initRepositories(RepositorySystem, RepositorySystemSession, List)} has to be called first.
      *
      * @return an instance of MavenArtifactResolver
      */
@@ -98,77 +81,24 @@ public class MavenArtifactResolver {
         return instance;
     }
 
-    private MavenArtifactResolver(List<Repository> repositories) {
-        repositorySystem = createRepositorySystem();
-        systemSession = createRepositorySystemSession(repositorySystem, DEFAULT_LOCAL_REPO);
-        remoteRepositories = new LinkedList<>();
-        repositories.forEach(r -> {
-            org.apache.maven.model.RepositoryPolicy releases = r.getReleases();
-            RepositoryPolicy releasesRepositoryPolicy = null;
-            if (releases != null) {
-                releasesRepositoryPolicy = new RepositoryPolicy(releases.isEnabled(),
-                        releases.getUpdatePolicy() == null ? UPDATE_POLICY_NEVER : releases.getUpdatePolicy(),
-                        releases.getChecksumPolicy());
-            }
-            RepositoryPolicy snapshotsRepositoryPolicy = null;
-            org.apache.maven.model.RepositoryPolicy snapshots = r.getSnapshots();
-            if (snapshots != null) {
-                snapshotsRepositoryPolicy = new RepositoryPolicy(snapshots.isEnabled(),
-                        snapshots.getUpdatePolicy() == null ? UPDATE_POLICY_NEVER : snapshots.getUpdatePolicy(),
-                        snapshots.getChecksumPolicy());
-            }
-            if (releasesRepositoryPolicy == null && snapshotsRepositoryPolicy == null) {
-                if (r.getUrl().toLowerCase(Locale.ROOT).contains("/release")) {
-                    releasesRepositoryPolicy = new RepositoryPolicy(true, UPDATE_POLICY_DAILY, CHECKSUM_POLICY_WARN);
-                    snapshotsRepositoryPolicy = new RepositoryPolicy(false, UPDATE_POLICY_DAILY, CHECKSUM_POLICY_WARN);
-                } else if (r.getUrl().toLowerCase(Locale.ROOT).contains("/snapshot")) {
-                    releasesRepositoryPolicy = new RepositoryPolicy(false, UPDATE_POLICY_DAILY, CHECKSUM_POLICY_WARN);
-                    snapshotsRepositoryPolicy = new RepositoryPolicy(true, UPDATE_POLICY_DAILY, CHECKSUM_POLICY_WARN);
-                }
-            }
-
-            RemoteRepository repository = new RemoteRepository
-                .Builder(r.getId(), "default", r.getUrl())
-                    .setReleasePolicy(releasesRepositoryPolicy)
-                    .setSnapshotPolicy(snapshotsRepositoryPolicy)
-                    .build();
-            remoteRepositories.add(repository);
-        });
+    private MavenArtifactResolver(RepositorySystem repositorySystem, RepositorySystemSession systemSession, List<RemoteRepository> repositories) {
+        this.repositorySystem = repositorySystem;
+        this.systemSession = systemSession;
+        this.remoteRepositories = repositories;
     }
 
     /**
      * Creates and initializes a new instance with a list of remote
      * repositories, only if such instance doesn't already exist
      *
-     * @param repositories a list of remote repositories
+     * @param repositorySystem The entry point to Maven Artifact Resolver
+     * @param systemSession The current repository/network configuration of Maven
      */
-    public static void initRepositories(List<Repository> repositories) {
+    public static void initRepositories(RepositorySystem repositorySystem, RepositorySystemSession systemSession, List<RemoteRepository> repositories) {
         if (instance != null) {
             return;
         }
-        instance = new MavenArtifactResolver(repositories);
-    }
-
-    // TODO: Find an alternative, as this only works up until Maven 3.8.7.
-    private RepositorySystem createRepositorySystem() {
-        DefaultServiceLocator serviceLocator = MavenRepositorySystemUtils.newServiceLocator();
-        serviceLocator.addService(RepositoryConnectorFactory.class, BasicRepositoryConnectorFactory.class);
-        serviceLocator.addService(TransporterFactory.class, FileTransporterFactory.class);
-        serviceLocator.addService(TransporterFactory.class, HttpTransporterFactory.class);
-        serviceLocator.setErrorHandler(new DefaultServiceLocator.ErrorHandler() {
-            @Override
-            public void serviceCreationFailed(Class<?> type, Class<?> impl, Throwable exception) {
-                throw new RuntimeException(exception);
-            }
-        });
-        return serviceLocator.getService(RepositorySystem.class);
-    }
-
-    private DefaultRepositorySystemSession createRepositorySystemSession(RepositorySystem system, String localRepoPath) {
-        DefaultRepositorySystemSession systemSession = MavenRepositorySystemUtils.newSession();
-        LocalRepository localRepo = new LocalRepository(localRepoPath);
-        systemSession.setLocalRepositoryManager(system.newLocalRepositoryManager(systemSession, localRepo));
-        return systemSession;
+        instance = new MavenArtifactResolver(repositorySystem, systemSession, repositories);
     }
 
     /**


### PR DESCRIPTION
Fixes #506, by removing unnecessary and deprecated way of getting an instance of a `RepositorySystem`, and a `RepositorySession`, by just getting these injected by Maven itself in the base Mojo.

Many dependencies from org.eclipse.aether/org.apache.maven.resolver are removed in the process, and therefore, the `org.eclipse.aether.connector.basic.BasicRepositoryConnectorFactory` [missing class](https://github.com/gluonhq/gluonfx-maven-plugin/issues/458#issuecomment-1462035876) from maven-core is not needed anymore.

Now, the plugin can run with any version up until 3.9.9 (latest before going to Maven 4, which is still in beta)