### PR TITLE
Update way to publish to maven central

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 11
-          server-id: ossrh
+          server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_CENTRAL_TOKEN
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 11
-          server-id: ossrh
+          server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_CENTRAL_TOKEN
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}

--- a/pom.xml
+++ b/pom.xml
@@ -119,14 +119,14 @@
         <version>3.15.0</version>
       </plugin>
       <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.13</version>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>0.7.0</version>
         <extensions>true</extensions>
         <configuration>
-          <serverId>ossrh</serverId>
-          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-          <autoReleaseAfterClose>true</autoReleaseAfterClose>
+          <publishingServerId>central</publishingServerId>
+          <autoPublish>true</autoPublish>
+          <waitUntil>published</waitUntil>
         </configuration>
       </plugin>
       <plugin>
@@ -254,15 +254,4 @@
     <connection>scm:git:git://github.com/gluonhq/gluonfx-maven-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com:gluonhq/gluonfx-maven-plugin.git</developerConnection>
   </scm>
-
-  <distributionManagement>
-    <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-    <repository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
-  </distributionManagement>
 </project>


### PR DESCRIPTION
Publishing to maven central will soon no longer be possible to the oss.sonatype.org nexus repository. See https://central.sonatype.org/news/20250326_ossrh_sunset/ for more information.

For maven we need to use sonatype's `central-publishing-maven-plugin` for artifact publication. A `distributionManagement` section is no longer required.